### PR TITLE
docs: fix simple typo, specifiy -> specify

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ The following embedded variables are provided:
 
 `Description:` Specify the response time threshold.
 Parameter rt is used to set a threshold of the average response time, in second.
-Parameter period is used to specifiy the period of the statistics cycle.
+Parameter period is used to specify the period of the statistics cycle.
 If the average response time of the system exceeds the threshold specified by the user,
 the incoming request will be redirected to a specified url which is defined by parameter 'action'.
 If no 'action' is presented, the request will be responsed with 503 error directly.


### PR DESCRIPTION
There is a small typo in README.md.

Should read `specify` rather than `specifiy`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md